### PR TITLE
Fixed incorrect routing for 404 error page

### DIFF
--- a/meteor-app/imports/ui/pages/not-found.js
+++ b/meteor-app/imports/ui/pages/not-found.js
@@ -8,7 +8,7 @@ export default () => (
     </div>
     <div className="not-found-title">
       <h1>Sorry, that page doesn’t exist</h1>
-      <a href={FlowRouter.url('/')} className="gotohomepage">Go to home</a>
+      <a href={FlowRouter.path('/')} className="gotohomepage">Go to home</a>
     </div>
   </div>
 );


### PR DESCRIPTION
This fixes issue #69 
This seems to be an existing issue: https://github.com/kadirahq/flow-router/issues/684, but the only solution stated was to remove the unwanted parts of the string using regular expressions.
By referencing the FlowRouter API at https://github.com/kadirahq/flow-router#api, note that FlowRouter.url is
> Just like FlowRouter.path, but gives the absolute url.

Changing FlowRouter.url to FlowRouter.path seems to fix this issue.