### PR TITLE
Added reusable component textmenu.js and header to index page

### DIFF
--- a/meteor-app/imports/startup/client/routes.js
+++ b/meteor-app/imports/startup/client/routes.js
@@ -13,6 +13,7 @@ import reducers from '/imports/ui/reducers';
 import FixedWidthLayout from '/imports/ui/layouts/fixed-width';
 import FullWindowLayout from '/imports/ui/layouts/full-window';
 import HomePage from '/imports/ui/pages/home';
+import {IndexHeader} from '/imports/ui/pages/home/index-header';
 import SearchPage from '/imports/ui/pages/search';
 import WorkspacePage from '/imports/ui/pages/tabbed-workspace';
 import Charts from '/imports/ui/components/workspace-charts';
@@ -58,9 +59,12 @@ FlowRouter.route('/', {
 
     mountWithStore(store, FixedWidthLayout, {
       header: (
-        <AppbarHeader
-          onClickHelpButton={() => alert('Show help for home page.')}
-        />
+        <div>
+          <AppbarHeader
+            onClickHelpButton={() => alert('Show help for home page.')}
+          />
+          <IndexHeader />
+        </div>
       ),
       body: <HomePage />,
       footer: null,

--- a/meteor-app/imports/startup/client/routes.js
+++ b/meteor-app/imports/startup/client/routes.js
@@ -13,7 +13,7 @@ import reducers from '/imports/ui/reducers';
 import FixedWidthLayout from '/imports/ui/layouts/fixed-width';
 import FullWindowLayout from '/imports/ui/layouts/full-window';
 import HomePage from '/imports/ui/pages/home';
-import {IndexHeader} from '/imports/ui/pages/home/index-header';
+import { IndexHeader } from '/imports/ui/pages/home/index-header';
 import SearchPage from '/imports/ui/pages/search';
 import WorkspacePage from '/imports/ui/pages/tabbed-workspace';
 import Charts from '/imports/ui/components/workspace-charts';

--- a/meteor-app/imports/ui/components/textmenu.js
+++ b/meteor-app/imports/ui/components/textmenu.js
@@ -1,0 +1,98 @@
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import MenuItem from 'material-ui/MenuItem';
+import FlatButton from 'material-ui/FlatButton';
+import Menu from 'material-ui/Menu';
+import Popover from 'material-ui/Popover';
+import Divider from 'material-ui/Divider';
+import React from 'react';
+
+export default class TextMenu extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { open: [] };
+    this.data = this.props.data;
+    for (let i = 0; i < this.data.length; i += 1) {
+      this.state.open.push(false);
+    }
+    this.numberOfElements = 0;
+  }
+
+  handleTouchTap(id, event) {
+    // This prevents ghost click.
+    event.preventDefault();
+
+    this.setState({
+      open: this.state.open.map((value, i) => (i === id ? true : value)),
+      anchorEl: event.currentTarget,
+    });
+  }
+
+  handleRequestClose(id) {
+    console.log("asdasd");
+    this.setState({
+      open: this.state.open.map((value, i) => (i === id ? false : value)),
+    });
+  }
+
+  convertRecursiveMenuItems(arrayOfItems, level) {
+    if (arrayOfItems==null)
+	return (null);
+
+    return (arrayOfItems.map((
+      (o,j) => {
+         let element = null;
+         if(o.type == 'menuitem') {
+           element = (<MenuItem primaryText={o.label} key={'menuitem' + this.numberOfElements} onClick={o.onClick}/>);
+         } else if(o.type == 'menuitem-group') {
+           let children = this.convertRecursiveMenuItems(o.items, level+1);
+           element = (<MenuItem primaryText={o.label} key={'menuitem' + this.numberOfElements} menuItems={children}/ >);
+         } else if(o.type == 'separator') {
+           element = (<Divider key={'divider' + this.numberOfElements}/>);
+         }
+         this.numberOfElements += 1;
+         return element;
+       }
+    )));
+  }
+
+  render() {
+    const reactComponents = [];
+
+    for (let i = 0; i < this.data.length; i += 1) {
+      reactComponents.push(
+        <FlatButton
+          onClick={this.handleTouchTap.bind(this, i)}
+          label={this.data[i].label}
+          key={'button' + i}
+          backgroundColor={'#f7f5e7'}
+        />);
+      this.numberOfElements += 1;
+      reactComponents.push(
+        <Popover
+          open={this.state.open[i]}
+          anchorEl={this.state.anchorEl}
+          anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+          targetOrigin={{ horizontal: 'left', vertical: 'top' }}
+          onRequestClose={this.handleRequestClose.bind(this, i)}
+          onMouseLeave={this.handleRequestClose.bind(this,i)}
+          key={'popover'+ (this.numberOfElements++)}
+        >
+          <Menu>
+            {
+              this.convertRecursiveMenuItems(this.data[i].items, 0)
+            }
+          </Menu>
+        </Popover>
+       );
+    } // for
+
+    return (
+      <MuiThemeProvider>
+        <div>
+          {reactComponents}
+        </div>
+      </MuiThemeProvider>
+    );
+  }
+}

--- a/meteor-app/imports/ui/components/textmenu.js
+++ b/meteor-app/imports/ui/components/textmenu.js
@@ -18,6 +18,9 @@ export default class TextMenu extends React.Component {
       this.state.open.push(false);
     }
     this.numberOfElements = 0;
+
+    this.handleTouchTap = this.handleTouchTap.bind(this);
+    this.handleRequestClose = this.handleRequestClose.bind(this);
   }
 
   handleTouchTap(id, event) {

--- a/meteor-app/imports/ui/components/textmenu.js
+++ b/meteor-app/imports/ui/components/textmenu.js
@@ -12,6 +12,7 @@ export default class TextMenu extends React.Component {
 
     this.state = { open: [] };
     this.data = this.props.data;
+    this.style = this.props.style;
     for (let i = 0; i < this.data.length; i += 1) {
       this.state.open.push(false);
     }
@@ -29,7 +30,6 @@ export default class TextMenu extends React.Component {
   }
 
   handleRequestClose(id) {
-    console.log("asdasd");
     this.setState({
       open: this.state.open.map((value, i) => (i === id ? false : value)),
     });
@@ -86,10 +86,11 @@ export default class TextMenu extends React.Component {
         </Popover>
        );
     } // for
+    let textMenuStyle = this.style.textMenuStyle;
 
     return (
       <MuiThemeProvider>
-        <div>
+        <div style={textMenuStyle}>
           {reactComponents}
         </div>
       </MuiThemeProvider>

--- a/meteor-app/imports/ui/components/textmenu.js
+++ b/meteor-app/imports/ui/components/textmenu.js
@@ -12,9 +12,7 @@ export default class TextMenu extends React.Component {
     super(props);
 
     this.state = { open: [] };
-    this.data = this.props.data;
-    this.style = this.props.style;
-    for (let i = 0; i < this.data.length; i += 1) {
+    for (let i = 0; i < this.props.data.length; i += 1) {
       this.state.open.push(false);
     }
     this.numberOfElements = 0;
@@ -48,12 +46,12 @@ export default class TextMenu extends React.Component {
       (o) => {
         let element = null;
         if (o.type === 'menuitem') {
-          element = (<MenuItem primaryText={o.label} key={`menuitem ${this.numberOfElements}`} onClick={o.onClick} />);
+          element = (<MenuItem primaryText={o.label} key={`menuitem${o.id}`} onClick={o.onClick} />);
         } else if (o.type === 'menuitem-group') {
           const children = this.convertRecursiveMenuItems(o.items, level + 1);
-          element = (<MenuItem primaryText={o.label} key={`menuitem' ${this.numberOfElements}`} menuItems={children} />);
+          element = (<MenuItem primaryText={o.label} key={`menuitem${o.id}`} menuItems={children} />);
         } else if (o.type === 'separator') {
-          element = (<Divider key={`divider' ${this.numberOfElements}`} />);
+          element = (<Divider key={`divider${o.id}`} />);
         }
         this.numberOfElements += 1;
         return element;
@@ -64,14 +62,15 @@ export default class TextMenu extends React.Component {
   render() {
     const reactComponents = [];
 
-    for (let i = 0; i < this.data.length; i += 1) {
+    for (let i = 0; i < this.props.data.length; i += 1) {
       reactComponents.push(
         <FlatButton
-          onClick={_.partial(this.handleTouchTap, i)}
-          label={this.data[i].label}
-          key={`button ${i}`}
+          onClick={(this.props.data[i].onClick == null) ? _.partial(this.handleTouchTap, i) : this.props.data[i].onClick}
+          label={this.props.data[i].label}
+          key={`button${i}`}
           backgroundColor={'#f7f5e7'}
-        />);
+        />,
+      );
       this.numberOfElements += 1;
       reactComponents.push(
         <Popover
@@ -81,17 +80,17 @@ export default class TextMenu extends React.Component {
           targetOrigin={{ horizontal: 'left', vertical: 'top' }}
           onRequestClose={_.partial(this.handleRequestClose, i)}
           onMouseLeave={_.partial(this.handleRequestClose, i)}
-          key={`popover ${(this.numberOfElements += 1)}`}
+          key={`popover${i}`}
         >
           <Menu>
             {
-              this.convertRecursiveMenuItems(this.data[i].items, 0)
+              this.convertRecursiveMenuItems(this.props.data[i].items, 0)
             }
           </Menu>
         </Popover>,
        );
     } // for
-    const textMenuStyle = this.style.textMenuStyle;
+    const textMenuStyle = this.props.style.textMenuStyle;
 
     return (
       <MuiThemeProvider>

--- a/meteor-app/imports/ui/components/textmenu.js
+++ b/meteor-app/imports/ui/components/textmenu.js
@@ -5,6 +5,7 @@ import Menu from 'material-ui/Menu';
 import Popover from 'material-ui/Popover';
 import Divider from 'material-ui/Divider';
 import React from 'react';
+import _ from 'lodash';
 
 export default class TextMenu extends React.Component {
   constructor(props) {
@@ -36,23 +37,24 @@ export default class TextMenu extends React.Component {
   }
 
   convertRecursiveMenuItems(arrayOfItems, level) {
-    if (arrayOfItems==null)
-	return (null);
+    if (arrayOfItems == null) {
+      return (null);
+    }
 
     return (arrayOfItems.map((
-      (o,j) => {
-         let element = null;
-         if(o.type == 'menuitem') {
-           element = (<MenuItem primaryText={o.label} key={'menuitem' + this.numberOfElements} onClick={o.onClick}/>);
-         } else if(o.type == 'menuitem-group') {
-           let children = this.convertRecursiveMenuItems(o.items, level+1);
-           element = (<MenuItem primaryText={o.label} key={'menuitem' + this.numberOfElements} menuItems={children}/ >);
-         } else if(o.type == 'separator') {
-           element = (<Divider key={'divider' + this.numberOfElements}/>);
-         }
-         this.numberOfElements += 1;
-         return element;
-       }
+      (o) => {
+        let element = null;
+        if (o.type === 'menuitem') {
+          element = (<MenuItem primaryText={o.label} key={`menuitem ${this.numberOfElements}`} onClick={o.onClick} />);
+        } else if (o.type === 'menuitem-group') {
+          const children = this.convertRecursiveMenuItems(o.items, level + 1);
+          element = (<MenuItem primaryText={o.label} key={`menuitem' ${this.numberOfElements}`} menuItems={children} />);
+        } else if (o.type === 'separator') {
+          element = (<Divider key={`divider' ${this.numberOfElements}`} />);
+        }
+        this.numberOfElements += 1;
+        return element;
+      }
     )));
   }
 
@@ -62,9 +64,9 @@ export default class TextMenu extends React.Component {
     for (let i = 0; i < this.data.length; i += 1) {
       reactComponents.push(
         <FlatButton
-          onClick={this.handleTouchTap.bind(this, i)}
+          onClick={_.partial(this.handleTouchTap, i)}
           label={this.data[i].label}
-          key={'button' + i}
+          key={`button ${i}`}
           backgroundColor={'#f7f5e7'}
         />);
       this.numberOfElements += 1;
@@ -74,19 +76,19 @@ export default class TextMenu extends React.Component {
           anchorEl={this.state.anchorEl}
           anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
           targetOrigin={{ horizontal: 'left', vertical: 'top' }}
-          onRequestClose={this.handleRequestClose.bind(this, i)}
-          onMouseLeave={this.handleRequestClose.bind(this,i)}
-          key={'popover'+ (this.numberOfElements++)}
+          onRequestClose={_.partial(this.handleRequestClose, i)}
+          onMouseLeave={_.partial(this.handleRequestClose, i)}
+          key={`popover ${(this.numberOfElements += 1)}`}
         >
           <Menu>
             {
               this.convertRecursiveMenuItems(this.data[i].items, 0)
             }
           </Menu>
-        </Popover>
+        </Popover>,
        );
     } // for
-    let textMenuStyle = this.style.textMenuStyle;
+    const textMenuStyle = this.style.textMenuStyle;
 
     return (
       <MuiThemeProvider>

--- a/meteor-app/imports/ui/pages/home/index-header.js
+++ b/meteor-app/imports/ui/pages/home/index-header.js
@@ -1,0 +1,102 @@
+/*
+ * Home page.
+ */
+
+import React from 'react';
+import IconMenu from 'material-ui/IconMenu';
+import MenuItem from 'material-ui/MenuItem';
+import IconButton from 'material-ui/IconButton';
+import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import TextMenu from '/imports/ui/components/textmenu';
+
+export function IndexHeader(props) {
+  var dataVar = [];
+  var itemsArr = [{type: 'menuitem', label:'SKOPE NSF Proposal'}, 
+                  {type: 'menuitem', label:'SKOPE Prototype'},
+                  {type: 'menuitem', label:'Stories'}];
+  dataVar.push({type: 'menu', label:'What is SKOPE?', items:itemsArr});
+
+  function someFunction() {
+    FlowRouter.go('/imports/ui/components/appbar.js');
+  }
+
+  var itemsArr2 = [
+    {type: 'menuitem', label: 'FedData', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'PaleoCAR', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'Risk Landscapes', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'SKOPE Prototype', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'Web Resources', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+  ];
+  dataVar.push({type:'menu', label:'Environmental Data', items:itemsArr2});
+  var itemsArr3 = [
+    {type: 'menuitem', label: 'YesWorkflow', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+  ];
+  dataVar.push({type:'menu', label:'Provenance', items:itemsArr3});
+  dataVar.push({type:'menu', label:'Data Integration'});
+  var itemsArr4 = [
+    {type: 'menuitem', label: "Prototype User's Guide", onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'Run SKOPE Prototype', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+  ];
+  dataVar.push({type:'menu', label:'SKOPE Prototype', items:itemsArr4});
+  var itemsArr5 = [
+    {type: 'menuitem', label: "Publications", onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: "Presentations", onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'SKOPE Prototype', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+    {type: 'menuitem', label: 'YesWorkflow', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
+  ];
+  dataVar.push({type:'menu', label:'Products', items:itemsArr5});
+  dataVar.push({type:'menu', label:'SKOPE Team'});
+  return (<TextMenu data={dataVar}/>);
+
+/*  return (
+  <MuiThemeProvider>
+  <div>
+    <IconMenu
+      iconButtonElement={<IconButton><p>Some text here</p></IconButton>}
+      anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+      targetOrigin={{horizontal: 'left', vertical: 'top'}}
+    >
+      <MenuItem primaryText="Refresh" />
+      <MenuItem primaryText="Send feedback" />
+      <MenuItem primaryText="Settings" />
+      <MenuItem primaryText="Help" />
+      <MenuItem primaryText="Sign out" />
+    </IconMenu>
+    <IconMenu
+      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
+      anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
+      targetOrigin={{horizontal: 'left', vertical: 'bottom'}}
+    >
+      <MenuItem primaryText="Refresh" />
+      <MenuItem primaryText="Send feedback" />
+      <MenuItem primaryText="Settings" />
+      <MenuItem primaryText="Help" />
+      <MenuItem primaryText="Sign out" />
+    </IconMenu>
+    <IconMenu
+      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
+      anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+      targetOrigin={{horizontal: 'right', vertical: 'bottom'}}
+    >
+      <MenuItem primaryText="Refresh" />
+      <MenuItem primaryText="Send feedback" />
+      <MenuItem primaryText="Settings" />
+      <MenuItem primaryText="Help" />
+      <MenuItem primaryText="Sign out" />
+    </IconMenu>
+    <IconMenu
+      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
+      anchorOrigin={{horizontal: 'right', vertical: 'top'}}
+      targetOrigin={{horizontal: 'right', vertical: 'top'}}
+    >
+      <MenuItem primaryText="Refresh" />
+      <MenuItem primaryText="Send feedback" />
+      <MenuItem primaryText="Settings" />
+      <MenuItem primaryText="Help" />
+      <MenuItem primaryText="Sign out" />
+    </IconMenu>
+  </div>
+  </MuiThemeProvider>); */
+};

--- a/meteor-app/imports/ui/pages/home/index-header.js
+++ b/meteor-app/imports/ui/pages/home/index-header.js
@@ -3,77 +3,69 @@
  */
 
 import React from 'react';
-import IconMenu from 'material-ui/IconMenu';
-import MenuItem from 'material-ui/MenuItem';
-import IconButton from 'material-ui/IconButton';
-import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import TextMenu from '/imports/ui/components/textmenu';
 
 export function IndexHeader(props) {
-  var dataVar = [];
-  var itemsArr = [{type: 'menuitem', label:'SKOPE NSF Proposal'}, 
-                  {type: 'menuitem', label:'SKOPE Prototype'},
-                  {type: 'menuitem', label:'Stories'}];
-  dataVar.push({type: 'menu', label:'What is SKOPE?', items:itemsArr});
+  super(props);
+  const dataVar = [];
+  const itemsArr = [{ type: 'menuitem', label: 'SKOPE NSF Proposal' },
+                  { type: 'menuitem', label: 'SKOPE Prototype' },
+                  { type: 'menuitem', label: 'Stories' }];
+  dataVar.push({ type: 'menu', label: 'What is SKOPE?', items: itemsArr });
 
-  function someFunction() {
-    FlowRouter.go('/imports/ui/components/appbar.js');
-  }
+  const itemsArr2 = [
+    { type: 'menuitem', label: 'FedData', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'PaleoCAR', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'Risk Landscapes', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'Web Resources', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+  ];
+  dataVar.push({ type: 'menu', label: 'Environmental Data', items: itemsArr2 });
+  const itemsArr3 = [
+    { type: 'menuitem', label: 'YesWorkflow', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+  ];
+  dataVar.push({ type: 'menu', label: 'Provenance', items: itemsArr3 });
+  dataVar.push({ type: 'menu', label: 'Data Integration' });
+  const itemsArr4 = [
+    { type: 'menuitem', label: "Prototype User's Guide", onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'Run SKOPE Prototype', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+  ];
+  dataVar.push({ type: 'menu', label: 'SKOPE Prototype', items: itemsArr4 });
+  const itemsArr5 = [
+    { type: 'menuitem', label: 'Publications', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'Presentations', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'YesWorkflow', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+  ];
+  dataVar.push({ type: 'menu', label: 'Products', items: itemsArr5 });
+  dataVar.push({ type: 'menu', label: 'SKOPE Team' });
 
-  var itemsArr2 = [
-    {type: 'menuitem', label: 'FedData', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'PaleoCAR', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'Risk Landscapes', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'SKOPE Prototype', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'Web Resources', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-  ];
-  dataVar.push({type:'menu', label:'Environmental Data', items:itemsArr2});
-  var itemsArr3 = [
-    {type: 'menuitem', label: 'YesWorkflow', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-  ];
-  dataVar.push({type:'menu', label:'Provenance', items:itemsArr3});
-  dataVar.push({type:'menu', label:'Data Integration'});
-  var itemsArr4 = [
-    {type: 'menuitem', label: "Prototype User's Guide", onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'Run SKOPE Prototype', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-  ];
-  dataVar.push({type:'menu', label:'SKOPE Prototype', items:itemsArr4});
-  var itemsArr5 = [
-    {type: 'menuitem', label: "Publications", onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: "Presentations", onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'SKOPE Prototype', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-    {type: 'menuitem', label: 'YesWorkflow', onClick: () => {FlowRouter.go('/imports/ui/components/hahahahaha');}},
-  ];
-  dataVar.push({type:'menu', label:'Products', items:itemsArr5});
-  dataVar.push({type:'menu', label:'SKOPE Team'});
+  const styleVar = { textMenuStyle: { margin: '0px', border: '0px', backgroundColor: 'rgb(247, 245, 231)', textAlign: 'center' } };
 
-  let styleVar = {textMenuStyle: {margin: '0px', border: '0px', backgroundColor: 'rgb(247, 245, 231)', textAlign: 'center'}};
-  
-  let imageStyle = {
-      background:'url(https://www.openskope.org/wp-content/uploads/2015/03/cropped-grissno2ce4.jpg) no-repeat scroll top',
-      height: '230px',
-      border: '0px',
-      margin: '0px',
-      padding: '0px 0px 0px 0px'
-    };
+  const imageStyle = {
+    background: 'url(https://www.openskope.org/wp-content/uploads/2015/03/cropped-grissno2ce4.jpg) no-repeat scroll top',
+    height: '230px',
+    border: '0px',
+    margin: '0px',
+    padding: '0px 0px 0px 0px',
+  };
 
-  let h1Style = {
+  const h1Style = {
     fontFamily: 'Bitter, Georgia, serif',
     color: '#ac0404',
     fontWeight: 'bold',
     fontSize: '60px',
     lineHeight: '1',
     margin: '0px',
-    padding: '58px 40px 10px'
+    padding: '58px 40px 10px',
   };
 
-  let h2Style = {
+  const h2Style = {
     font: '300 italic 24px "Source Sans Pro", Helvetica, sans-serif',
     color: '#960028',
     margin: '0',
-    padding: '0px 40px'
+    padding: '0px 40px',
   };
 
   return (
@@ -82,57 +74,7 @@ export function IndexHeader(props) {
         <h1 style={h1Style}>SKOPE</h1>
         <h2 style={h2Style}>Synthesizing Knowledge of Past Environments</h2>
       </div>
-      <TextMenu style={styleVar} data={dataVar}/>
+      <TextMenu style={styleVar} data={dataVar} />
     </div>
   );
-
-/*  return (
-  <MuiThemeProvider>
-  <div>
-    <IconMenu
-      iconButtonElement={<IconButton><p>Some text here</p></IconButton>}
-      anchorOrigin={{horizontal: 'left', vertical: 'top'}}
-      targetOrigin={{horizontal: 'left', vertical: 'top'}}
-    >
-      <MenuItem primaryText="Refresh" />
-      <MenuItem primaryText="Send feedback" />
-      <MenuItem primaryText="Settings" />
-      <MenuItem primaryText="Help" />
-      <MenuItem primaryText="Sign out" />
-    </IconMenu>
-    <IconMenu
-      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
-      anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
-      targetOrigin={{horizontal: 'left', vertical: 'bottom'}}
-    >
-      <MenuItem primaryText="Refresh" />
-      <MenuItem primaryText="Send feedback" />
-      <MenuItem primaryText="Settings" />
-      <MenuItem primaryText="Help" />
-      <MenuItem primaryText="Sign out" />
-    </IconMenu>
-    <IconMenu
-      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
-      anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
-      targetOrigin={{horizontal: 'right', vertical: 'bottom'}}
-    >
-      <MenuItem primaryText="Refresh" />
-      <MenuItem primaryText="Send feedback" />
-      <MenuItem primaryText="Settings" />
-      <MenuItem primaryText="Help" />
-      <MenuItem primaryText="Sign out" />
-    </IconMenu>
-    <IconMenu
-      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
-      anchorOrigin={{horizontal: 'right', vertical: 'top'}}
-      targetOrigin={{horizontal: 'right', vertical: 'top'}}
-    >
-      <MenuItem primaryText="Refresh" />
-      <MenuItem primaryText="Send feedback" />
-      <MenuItem primaryText="Settings" />
-      <MenuItem primaryText="Help" />
-      <MenuItem primaryText="Sign out" />
-    </IconMenu>
-  </div>
-  </MuiThemeProvider>); */
-};
+}

--- a/meteor-app/imports/ui/pages/home/index-header.js
+++ b/meteor-app/imports/ui/pages/home/index-header.js
@@ -3,42 +3,42 @@
  */
 
 import React from 'react';
-import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import TextMenu from '/imports/ui/components/textmenu';
 
 export function IndexHeader() {
-  const dataVar = [];
-  const itemsArr = [{ type: 'menuitem', label: 'SKOPE NSF Proposal' },
-                  { type: 'menuitem', label: 'SKOPE Prototype' },
-                  { type: 'menuitem', label: 'Stories' }];
-  dataVar.push({ type: 'menu', label: 'What is SKOPE?', items: itemsArr });
-
+  const itemsArr = [{ type: 'menuitem', label: 'SKOPE NSF Proposal', onClick: () => { window.location.href = 'https://www.openskope.org/skope-nsf-proposal'; }, id: '1' },
+                  { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { window.location.href = 'https://www.openskope.org/skope-prototype'; }, id: '2' },
+                  { type: 'menuitem', label: 'Stories', onClick: () => { window.location.href = 'https://www.openskope.org/sample-questions-of-the-sort-skope-plans-to-address'; }, id: '3' }];
   const itemsArr2 = [
-    { type: 'menuitem', label: 'FedData', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'PaleoCAR', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'Risk Landscapes', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'Web Resources', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'FedData', onClick: () => { window.location.href = 'https://www.openskope.org/feddata'; }, id: '4' },
+    { type: 'menuitem', label: 'PaleoCAR', onClick: () => { window.location.href = 'https://www.openskope.org/paleoenvironmental-reconstruction-paleocar'; }, id: '5' },
+    { type: 'menuitem', label: 'Risk Landscapes', onClick: () => { window.location.href = 'https://www.openskope.org/risk-landscapes'; }, id: '6' },
+    { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { window.location.href = 'https://www.openskope.org/skope-prototype'; }, id: '7' },
+    { type: 'menuitem', label: 'Web Resources', onClick: () => { window.location.href = 'https://www.openskope.org/skope-prototype'; }, id: '8' },
   ];
-  dataVar.push({ type: 'menu', label: 'Environmental Data', items: itemsArr2 });
   const itemsArr3 = [
-    { type: 'menuitem', label: 'YesWorkflow', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'YesWorkflow', onClick: () => { window.location.href = 'https://www.openskope.org/yesworkflow'; }, id: '9' },
   ];
-  dataVar.push({ type: 'menu', label: 'Provenance', items: itemsArr3 });
-  dataVar.push({ type: 'menu', label: 'Data Integration' });
   const itemsArr4 = [
-    { type: 'menuitem', label: "Prototype User's Guide", onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'Run SKOPE Prototype', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: "Prototype User's Guide", onClick: () => { window.location.href = 'https://www.openskope.org/skope-prototype-users-guide'; }, id: '10' },
+    { type: 'menuitem', label: 'Run SKOPE Prototype', onClick: () => { window.location.href = 'http://demo.openskope.org/browse/'; }, id: '11' },
   ];
-  dataVar.push({ type: 'menu', label: 'SKOPE Prototype', items: itemsArr4 });
   const itemsArr5 = [
-    { type: 'menuitem', label: 'Publications', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'Presentations', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
-    { type: 'menuitem', label: 'YesWorkflow', onClick: () => { FlowRouter.go('/imports/ui/components/hahahahaha'); } },
+    { type: 'menuitem', label: 'Publications', onClick: () => { window.location.href = 'http://demo.openskope.org/browse/'; }, id: '12' },
+    { type: 'menuitem', label: 'Presentations', onClick: () => { window.location.href = 'https://www.openskope.org/presentations'; }, id: '13' },
+    { type: 'menuitem', label: 'SKOPE Prototype', onClick: () => { window.location.href = 'https://www.openskope.org/presentations'; }, id: '14' },
+    { type: 'menuitem', label: 'YesWorkflow', onClick: () => { window.location.href = 'https://www.openskope.org/yesworkflow'; }, id: '15' },
   ];
-  dataVar.push({ type: 'menu', label: 'Products', items: itemsArr5 });
-  dataVar.push({ type: 'menu', label: 'SKOPE Team' });
+
+  const dataVar = [
+    { type: 'menu', label: 'What is SKOPE?', items: itemsArr },
+    { type: 'menu', label: 'Environmental Data', items: itemsArr2 },
+    { type: 'menu', label: 'Provenance', items: itemsArr3 },
+    { type: 'menu', label: 'Data Integration', onClick: () => { window.location.href = 'https://www.openskope.org/data-integration'; } },
+    { type: 'menu', label: 'SKOPE Prototype', items: itemsArr4 },
+    { type: 'menu', label: 'Products', items: itemsArr5 },
+    { type: 'menu', label: 'SKOPE Team', onClick: () => { window.location.href = 'https://www.openskope.org/data-integration'; } },
+  ];
 
   const styleVar = { textMenuStyle: { margin: '0px', border: '0px', backgroundColor: 'rgb(247, 245, 231)', textAlign: 'center' } };
 

--- a/meteor-app/imports/ui/pages/home/index-header.js
+++ b/meteor-app/imports/ui/pages/home/index-header.js
@@ -6,8 +6,7 @@ import React from 'react';
 import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import TextMenu from '/imports/ui/components/textmenu';
 
-export function IndexHeader(props) {
-  super(props);
+export function IndexHeader() {
   const dataVar = [];
   const itemsArr = [{ type: 'menuitem', label: 'SKOPE NSF Proposal' },
                   { type: 'menuitem', label: 'SKOPE Prototype' },

--- a/meteor-app/imports/ui/pages/home/index-header.js
+++ b/meteor-app/imports/ui/pages/home/index-header.js
@@ -48,7 +48,43 @@ export function IndexHeader(props) {
   ];
   dataVar.push({type:'menu', label:'Products', items:itemsArr5});
   dataVar.push({type:'menu', label:'SKOPE Team'});
-  return (<TextMenu data={dataVar}/>);
+
+  let styleVar = {textMenuStyle: {margin: '0px', border: '0px', backgroundColor: 'rgb(247, 245, 231)', textAlign: 'center'}};
+  
+  let imageStyle = {
+      background:'url(https://www.openskope.org/wp-content/uploads/2015/03/cropped-grissno2ce4.jpg) no-repeat scroll top',
+      height: '230px',
+      border: '0px',
+      margin: '0px',
+      padding: '0px 0px 0px 0px'
+    };
+
+  let h1Style = {
+    fontFamily: 'Bitter, Georgia, serif',
+    color: '#ac0404',
+    fontWeight: 'bold',
+    fontSize: '60px',
+    lineHeight: '1',
+    margin: '0px',
+    padding: '58px 40px 10px'
+  };
+
+  let h2Style = {
+    font: '300 italic 24px "Source Sans Pro", Helvetica, sans-serif',
+    color: '#960028',
+    margin: '0',
+    padding: '0px 40px'
+  };
+
+  return (
+    <div>
+      <div style={imageStyle}>
+        <h1 style={h1Style}>SKOPE</h1>
+        <h2 style={h2Style}>Synthesizing Knowledge of Past Environments</h2>
+      </div>
+      <TextMenu style={styleVar} data={dataVar}/>
+    </div>
+  );
 
 /*  return (
   <MuiThemeProvider>


### PR DESCRIPTION
Created a reusable component textmenu.js. It can take in an array of menus, each containing an array of menuitems. Ech menuitem also takes in an onClick function that is called when the item is clicked. Recursive submenus are allowed by modifying 'type' in the JSON object as menuitem-group for the menuitem containing submenus. 'type' can be specified as 'separator' to allow for a separator between menuitems.

We used this component in index.js under pages/home as the header, mimicking openskope.org