### PR TITLE
Fix temporal filter matching logic

### DIFF
--- a/meteor-app/imports/ui/pages/search-by-map/component.js
+++ b/meteor-app/imports/ui/pages/search-by-map/component.js
@@ -117,6 +117,7 @@ export default class SearchPage extends React.Component {
             fields={[
               'timespan.period',
             ]}
+            relation="contains"
             min={moment('0000', 'YYYY').toDate()}
             max={moment().toDate()}
             resolution="month"

--- a/meteor-app/imports/ui/pages/search-by-map/filter-components/data-temporal-range-filter.js
+++ b/meteor-app/imports/ui/pages/search-by-map/filter-components/data-temporal-range-filter.js
@@ -299,7 +299,7 @@ class DateRangeInput extends React.Component {
  * An extended version of RangeFilter to support multi-field range filtering
  * and aggregation.
  */
-export default class DataTemporalRangeFilter extends RangeFilter {
+class DataTemporalRangeFilter extends RangeFilter {
   static propTypes = {
     ...RangeFilter.propTypes,
     fields: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -431,3 +431,5 @@ export default class DataTemporalRangeFilter extends RangeFilter {
     });
   };
 }
+
+export default DataTemporalRangeFilter;

--- a/meteor-app/imports/ui/pages/search-by-map/filter-components/data-temporal-range-filter.js
+++ b/meteor-app/imports/ui/pages/search-by-map/filter-components/data-temporal-range-filter.js
@@ -158,6 +158,10 @@ class DateRangeInput extends React.Component {
   };
 
   static defaultProps = {
+    min: null,
+    max: null,
+    minValue: null,
+    maxValue: null,
     onChange: () => {},
     onFinished: () => {},
     resolution: 'date',


### PR DESCRIPTION
This resolves #100.

Now it's using "contains" instead of "within" for range matching.

"contains" will make sure all matched results contain the specified filtering range.

See https://www.elastic.co/guide/en/elasticsearch/reference/6.0/range.html for related documentation on range query.