### PR TITLE
Allow only one variable to be selected.

### DIFF
--- a/meteor-app/imports/ui/pages/dynamic-workspace/suites/dataset.js
+++ b/meteor-app/imports/ui/pages/dynamic-workspace/suites/dataset.js
@@ -225,7 +225,7 @@ export default class Component extends SuiteBaseClass {
   );
   setLayerVisibility = (layerId, isVisible) => this.setState({
     layerVisibility: {
-      ...this.state.layerVisibility,
+      // ...this.state.layerVisibility, // Enable this line to allow multi-select.
       [layerId]: isVisible,
     },
   });


### PR DESCRIPTION
This quick fix basically stops preserving selection state, therefore only the last selection takes effect.