### PR TITLE
Fix analytics point requests

### DIFF
--- a/meteor-app/imports/ui/pages/dynamic-workspace/suites/dataset.analytics.js
+++ b/meteor-app/imports/ui/pages/dynamic-workspace/suites/dataset.analytics.js
@@ -38,6 +38,7 @@ import {
   offsetDateAtPrecision,
   makeSVGDocAsync,
   svgDocToBlob,
+  fillTemplateString,
 } from '/imports/ui/helpers';
 
 import MapView from '/imports/ui/components/mapview';
@@ -249,10 +250,30 @@ class AnalyticsTab extends TabComponentClass {
     }
 
     const analytics = this.getAnalyticsByName(payload.variableName);
-    //! Fill this url with state values if needed.
-    const remoteUrl = analytics.url;
+    // const requestBody = {};
+    const remoteUrl = fillTemplateString(
+      analytics.url,
+      {
+        LAT: () => {
+          if (payload.boundaryGeometry.type === 'Point') {
+            return payload.boundaryGeometry.coordinates[1];
+          }
 
-    console.log('requestData', 'requesting', analytics.url);
+          return null;
+        },
+        LONG: () => {
+          if (payload.boundaryGeometry.type === 'Point') {
+            return payload.boundaryGeometry.coordinates[0];
+          }
+
+          return null;
+        },
+        boundaryGeometry: payload.boundaryGeometry,
+      },
+      // requestBody,
+    );
+
+    console.log('requestData', 'requesting', remoteUrl);
 
     this.setState({
       isLoadingTimeSeriesData: true,
@@ -266,6 +287,7 @@ class AnalyticsTab extends TabComponentClass {
       remoteUrl,
       {
         json: true,
+        // data: requestBody,
       },
       (error, response) => {
         if (error) {

--- a/meteor-app/imports/ui/pages/dynamic-workspace/suites/dataset.analytics.js
+++ b/meteor-app/imports/ui/pages/dynamic-workspace/suites/dataset.analytics.js
@@ -586,7 +586,7 @@ class AnalyticsTab extends TabComponentClass {
               }}
               zDepth={2}
             >
-              <h4>Select a variable and a boundary to view the time serires data.</h4>
+              <p>Select <b>a variable</b> and <b>a valid point in the boundary</b> to view the time serires data.</p>
             </Paper>
           )}
         </Paper>


### PR DESCRIPTION
Due to backend not supporting reading query parameters from the url when dealing with `POST` requests, I had to use the `GET` method and put lat. and long. values in the url.

Ugly fix, should revert changes in `dataset.analytics.js`.

This resolves #122.